### PR TITLE
Make config changes specific to this plugin's config only

### DIFF
--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -226,7 +226,10 @@ public class AttackTimerMetronomePlugin extends Plugin
     @Subscribe
     public void onConfigChanged(ConfigChanged event)
     {
-        attackDelayHoldoffTicks = 0;
+        if (event.getGroup().equals("attacktimermetronome"))
+        {
+            attackDelayHoldoffTicks = 0;
+        }
     }
 
     @Override


### PR DESCRIPTION
Likely fixes stuff like this: https://github.com/lejeffe/MonsterHP/pull/18
I don't know your plugin's code well enough to know if  ```attackDelayHoldoffTicks = 0;``` should only be set when a specific config option is changed. That is a possibility as well. This just makes sure attackDelayHoldoffTicks is only set to 0 when config options from attacktimer change.