### PR TITLE
Make Tick Counter Movable

### DIFF
--- a/src/main/java/com/attacktimer/AttackTimerMetronomeTileOverlay.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomeTileOverlay.java
@@ -1,9 +1,10 @@
-package com.attacktimer;
+package net.runelite.client.plugins.attacktimer;
 
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.plugins.GameTickInfo.GameTickInfoPlugin;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -18,14 +19,21 @@ import java.awt.Font;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
 
 
-public class AttackTimerMetronomeTileOverlay extends Overlay
+public class AttackTimerMetronomeTileOverlay extends OverlayPanel
 {
 
     private final Client client;
     private final AttackTimerMetronomeConfig config;
     private final AttackTimerMetronomePlugin plugin;
+    private final PanelComponent AttackTimerMetronomeTileOverlay = new PanelComponent();
 
     @Inject
     public AttackTimerMetronomeTileOverlay(Client client, AttackTimerMetronomeConfig config, AttackTimerMetronomePlugin plugin)
@@ -34,14 +42,16 @@ public class AttackTimerMetronomeTileOverlay extends Overlay
         this.client = client;
         this.config = config;
         this.plugin = plugin;
-        setPosition(OverlayPosition.DYNAMIC);
-        setLayer(OverlayLayer.UNDER_WIDGETS);
+        setPosition(OverlayPosition.TOP_LEFT);
+        setLayer(OverlayLayer.ABOVE_WIDGETS);
         setPriority(OverlayPriority.MED);
+        isResizable();
     }
 
     @Override
     public Dimension render(Graphics2D graphics)
     {
+        int ticksRemaining = plugin.getTicksUntilNextAttack();
         if (plugin.attackState != AttackTimerMetronomePlugin.AttackState.DELAYED) {
             return null;
         }
@@ -57,17 +67,27 @@ public class AttackTimerMetronomeTileOverlay extends Overlay
                 graphics.setFont(new Font(config.fontType().toString(), Font.PLAIN, config.fontSize()));
             }
 
-            final int height = client.getLocalPlayer().getLogicalHeight()+20;
-            final LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
-            final Point playerPoint = Perspective.localToCanvas(client, localLocation, client.getPlane(), height);
+            String timeToDisplay = String.valueOf(ticksRemaining);
+
+            AttackTimerMetronomeTileOverlay.getChildren().clear();
+            AttackTimerMetronomeTileOverlay.getChildren().add(TitleComponent.builder()
+                            .text(timeToDisplay)
+                            .color(config.NumberColor())
+                            .build());
+
+
+         //   final int height = client.getLocalPlayer().getLogicalHeight()+20;
+        //    final LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
+         //   final Point playerPoint = Perspective.localToCanvas(client, localLocation, client.getPlane(), height);
 
             // Countdown ticks instead of up.
             // plugin.tickCounter => ticksRemaining
-            int ticksRemaining = plugin.getTicksUntilNextAttack();
-            OverlayUtil.renderTextLocation(graphics, playerPoint, String.valueOf(ticksRemaining), config.NumberColor());
+            AttackTimerMetronomeTileOverlay.setPreferredSize(new Dimension(graphics.getFontMetrics().stringWidth(String.valueOf(GameTickInfoPlugin.timeSinceCycleStart))+10,0));
+           //int ticksRemaining = plugin.getTicksUntilNextAttack();
+           // OverlayUtil.renderTextLocation(graphics, playerPoint, String.valueOf(ticksRemaining), config.NumberColor());
         }
-
-        return null;
+        return AttackTimerMetronomeTileOverlay.render(graphics);
+        //return null;
     }
 
     private void renderTile(final Graphics2D graphics, final LocalPoint dest, final Color color, final Color fillColor, final double borderWidth)


### PR DESCRIPTION
Allows the User to use ALT to move the Tick counter location on screen rather then it just being above your head.  The other config options ie font size, font color still apply. 

I love this plugin, and literally downloaded intelj compiled runelite forked this plugin and learned java to add this lmao. So please add the changes :)