### PR TITLE
chore: avoid deprecated method

### DIFF
--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -201,7 +201,7 @@ public class AttackTimerMetronomePlugin extends Plugin
 
     private ItemStats getWeaponStats(int weaponId)
     {
-        return itemManager.getItemStats(weaponId, false);
+        return itemManager.getItemStats(weaponId);
     }
 
     private AttackStyle getAttackStyle()


### PR DESCRIPTION
Resolves
```
attacktimer: plugin uses terminally deprecated APIs:
Use the overloaded getItemStats(int itemId) method instead
```