### PR TITLE
Eye of Ayak Fix

### DIFF
--- a/src/main/java/com/attacktimer/AnimationData.java
+++ b/src/main/java/com/attacktimer/AnimationData.java
@@ -171,17 +171,17 @@ public enum AnimationData
     MAGIC_STANDARD_CRUMBLE_UNDEAD(724, AttackStyle.MAGIC, Spellbook.STANDARD),
     MAGIC_STANDARD_CRUMBLE_UNDEAD_HOLDING_STAFF(1166, AttackStyle.MAGIC, Spellbook.STANDARD),
     MAGIC_STANDARD_ENFEEBLE(1168, AttackStyle.MAGIC, Spellbook.STANDARD),
-    MAGIC_STANDARD_STRIKE_BOLT_BLAST(711, AttackStyle.MAGIC, Spellbook.STANDARD), // tested w/ bolt
-    MAGIC_STANDARD_STRIKE_BOLT_BLAST_STAFF(1162, AttackStyle.MAGIC, Spellbook.STANDARD), // strike, bolt and blast (tested all spells, different weapons)
+    MAGIC_STANDARD_STRIKE_BOLT_BLAST(9144, AttackStyle.MAGIC, Spellbook.STANDARD), // tested w/ bolt
+    MAGIC_STANDARD_STRIKE_BOLT_BLAST_STAFF(11423, AttackStyle.MAGIC, Spellbook.STANDARD), // strike, bolt and blast (tested all spells, different weapons)
     MAGIC_STANDARD_STUN(1169, AttackStyle.MAGIC, Spellbook.STANDARD),
-    MAGIC_STANDARD_SURGE_STAFF(7855, AttackStyle.MAGIC, Spellbook.STANDARD), // tested many staves
+    MAGIC_STANDARD_SURGE_STAFF(9145, AttackStyle.MAGIC, Spellbook.STANDARD), // tested many staves
     MAGIC_STANDARD_VULNERABILITY_CURSE(1165, AttackStyle.MAGIC, Spellbook.STANDARD),
-    MAGIC_STANDARD_WAVE(727, AttackStyle.MAGIC, Spellbook.STANDARD), // tested w/ wave spells
-    MAGIC_STANDARD_WAVE_STAFF(1167, AttackStyle.MAGIC, Spellbook.STANDARD), // tested many staves
+    MAGIC_STANDARD_WAVE(11429, AttackStyle.MAGIC, Spellbook.STANDARD), // tested w/ wave spells
+    MAGIC_STANDARD_WAVE_STAFF(11430, AttackStyle.MAGIC, Spellbook.STANDARD), // tested many staves
     MAGIC_STANDARD_WEAKEN(1164, AttackStyle.MAGIC, Spellbook.STANDARD),
 
-    MAGIC_ANCIENT_MULTI_TARGET(1979, AttackStyle.MAGIC, Spellbook.ANCIENT), // Burst & Barrage animations (tested all 8, different weapons)
-    MAGIC_ANCIENT_SINGLE_TARGET(1978, AttackStyle.MAGIC, Spellbook.ANCIENT), // Rush & Blitz animations (tested all 8, different weapons)
+    MAGIC_ANCIENT_MULTI_TARGET(10092, AttackStyle.MAGIC, Spellbook.ANCIENT), // Burst & Barrage animations (tested all 8, different weapons)
+    MAGIC_ANCIENT_SINGLE_TARGET(10091, AttackStyle.MAGIC, Spellbook.ANCIENT), // Rush & Blitz animations (tested all 8, different weapons)
 
     MAGIC_ARCEUUS_DEMONBANE(8977, AttackStyle.MAGIC, Spellbook.ARCEUUS), // Also greater corruption, so that may accidentally trigger a manual-cast, but that's probably fine only affects Muspah
     MAGIC_ARCEUUS_GRASP(8972, AttackStyle.MAGIC, Spellbook.ARCEUUS),

--- a/src/main/java/com/attacktimer/AnimationData.java
+++ b/src/main/java/com/attacktimer/AnimationData.java
@@ -191,6 +191,7 @@ public enum AnimationData
     MAGIC_WARPED_SCEPTRE(10501, AttackStyle.MAGIC, false), // https://oldschool.runescape.wiki/w/Warped_sceptre
     MAGIC_VOLATILE_NIGHTMARE_STAFF_SPEC(8532, AttackStyle.MAGIC, true), // assume 99 mage's base damage (does not rise when boosted).
 
+    MAGIC_EYE_OF_AYAK(12397, AttackStyle.MAGIC, false),
     MAGIC_EYE_OF_AYAK_SPEC(12394, AttackStyle.MAGIC, true), // https://github.com/ngraves95/attacktimer/issues/91
 
     // Misc

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -318,10 +318,10 @@ public class AttackTimerMetronomePlugin extends Plugin
         }
 
         AnimationData fromId = AnimationData.fromId(animationId);
-        if (fromId == AnimationData.RANGED_BLOWPIPE || fromId == AnimationData.RANGED_BLAZING_BLOWPIPE)
+        if (fromId == AnimationData.RANGED_BLOWPIPE || fromId == AnimationData.RANGED_BLAZING_BLOWPIPE || fromId == AnimationData.MAGIC_EYE_OF_AYAK || fromId == AnimationData.MAGIC_EYE_OF_AYAK_SPEC)
         {
-            // These two animations are the only ones which exceed the duration of their attack cooldown (when
-            // on rapid), so in this case DO NOT fall back the animation as it is un-reliable.
+            // These four animations are the only ones which exceed the duration of their attack cooldown
+            // so in this case DO NOT fall back the animation as it is un-reliable.
             return false;
         }
         // fall back to animations.


### PR DESCRIPTION
Due to the fact that the Eye of Ayak is a weapon that fires rapidly, similar to the blowpipe, it was not registering attacks correctly. These changes fix the above issue.

@ngraves95 