### PR TITLE
Eye of Ayak fixes

### DIFF
--- a/src/main/java/com/attacktimer/AnimationData.java
+++ b/src/main/java/com/attacktimer/AnimationData.java
@@ -191,6 +191,7 @@ public enum AnimationData
     MAGIC_WARPED_SCEPTRE(10501, AttackStyle.MAGIC, false), // https://oldschool.runescape.wiki/w/Warped_sceptre
     MAGIC_VOLATILE_NIGHTMARE_STAFF_SPEC(8532, AttackStyle.MAGIC, true), // assume 99 mage's base damage (does not rise when boosted).
 
+    MAGIC_EYE_OF_AYAK(12397, AttackStyle.MAGIC, false),
     MAGIC_EYE_OF_AYAK_SPEC(12394, AttackStyle.MAGIC, true), // https://github.com/ngraves95/attacktimer/issues/91
 
     // Misc

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -318,10 +318,10 @@ public class AttackTimerMetronomePlugin extends Plugin
         }
 
         AnimationData fromId = AnimationData.fromId(animationId);
-        if (fromId == AnimationData.RANGED_BLOWPIPE || fromId == AnimationData.RANGED_BLAZING_BLOWPIPE)
+        if (fromId == AnimationData.RANGED_BLOWPIPE || fromId == AnimationData.RANGED_BLAZING_BLOWPIPE || fromId == AnimationData.MAGIC_EYE_OF_AYAK || fromId == AnimationData.MAGIC_EYE_OF_AYAK_SPEC)
         {
-            // These two animations are the only ones which exceed the duration of their attack cooldown (when
-            // on rapid), so in this case DO NOT fall back the animation as it is un-reliable.
+            // These four animations are the only ones which exceed the duration of their attack cooldown
+            // so in this case DO NOT fall back the animation as it is un-reliable.
             return false;
         }
         // fall back to animations.


### PR DESCRIPTION
Due to the fact that the Eye of Ayak is a weapon that fires rapidly, similar to the blowpipe, it was not registering attacks correctly. These changes fix the above issue.

fixed commits from #96 @ngraves95
