### PR TITLE
Improve Eat Detection

### DIFF
--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -409,10 +409,8 @@ public class AttackTimerMetronomePlugin extends Plugin
                       FAST_EAT_ATTACK_DELAY_TICKS
                     : DEFAULT_FOOD_ATTACK_DELAY_TICKS;
 
-            if (isAttackCooldownPending())
-            {
-                pendingEatDelayTicks += attackDelay;
-            }
+            // We should always add eat delay
+            pendingEatDelayTicks += attackDelay;
         }
     }
 
@@ -479,9 +477,11 @@ public class AttackTimerMetronomePlugin extends Plugin
                 }
         }
 
+        // This needs to come after performAttack as it's an additive affect
         applyAndClearEats();
 
-        attackDelayHoldoffTicks--;
+        // clamp the holdoff at 0
+        attackDelayHoldoffTicks = Math.max(0, attackDelayHoldoffTicks - 1);
     }
 
 


### PR DESCRIPTION
This Patch refactors the eat detection to be regex based as if that's implemented properly it should be more performant that chaining `startsWith` and `contains` calls.

To actual fix the issues the detection matching has included some more cases:

* Fast eats:
  * Halibut
  * Gnome foods
* Barb potions are a type of food, which are rarely used I mostly ran into this at Yama when he drops them, these just need a special case like jugs of wine.

Fixes issue #103