### PR TITLE
Fix Harmonised Staff

### DIFF
--- a/src/main/java/com/attacktimer/AnimationData.java
+++ b/src/main/java/com/attacktimer/AnimationData.java
@@ -3,7 +3,7 @@ package com.attacktimer;
 /*
  * Copyright (c) 2021, Matsyir <https://github.com/matsyir>
  * Copyright (c) 2020, Mazhar <https://twitter.com/maz_rs>
- * Copyright (c) 2024-2025, Lexer747 <https://github.com/Lexer747>
+ * Copyright (c) 2024-2026, Lexer747 <https://github.com/Lexer747>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -172,6 +172,8 @@ public enum AnimationData
     MAGIC_STANDARD_CRUMBLE_UNDEAD_HOLDING_STAFF(1166, AttackStyle.MAGIC, Spellbook.STANDARD),
     MAGIC_STANDARD_ENFEEBLE(1168, AttackStyle.MAGIC, Spellbook.STANDARD),
     MAGIC_STANDARD_STRIKE_BOLT_BLAST(9144, AttackStyle.MAGIC, Spellbook.STANDARD), // tested w/ bolt
+    MAGIC_STANDARD_STRIKE_MANUAL(711, AttackStyle.MAGIC, Spellbook.STANDARD),
+    MAGIC_STANDARD_STRIKE_STAFF(1162, AttackStyle.MAGIC, Spellbook.STANDARD),
     MAGIC_STANDARD_STRIKE_BOLT_BLAST_STAFF(11423, AttackStyle.MAGIC, Spellbook.STANDARD), // strike, bolt and blast (tested all spells, different weapons)
     MAGIC_STANDARD_STUN(1169, AttackStyle.MAGIC, Spellbook.STANDARD),
     MAGIC_STANDARD_SURGE_STAFF(9145, AttackStyle.MAGIC, Spellbook.STANDARD), // tested many staves
@@ -342,7 +344,7 @@ public enum AnimationData
     public static boolean isManualCasting(AnimationData animationData)
     {
         // This check ensures we don't treat staff animations which are magic attacks as a "manual cast".
-        if (animationData.spellbook != null && animationData != null)
+        if (animationData != null && animationData.spellbook != null)
         {
             // We tell a manual cast by the animation data:
             return animationData.attackStyle == AttackStyle.MAGIC &&

--- a/src/main/java/com/attacktimer/PoweredStaves.java
+++ b/src/main/java/com/attacktimer/PoweredStaves.java
@@ -48,14 +48,19 @@ enum PoweredStaves
     WEAPON_BLUE_C_STAFF_P(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1720),23900), // https://oldschool.runescape.wiki/w/Crystal_staff_(perfected)
     WEAPON_BONE_STAFF(AnimationData.MELEE_GENERIC_SLASH, Projectiles(2647),  28796, 28797), //https://oldschool.runescape.wiki/w/Bone_staff
     WEAPON_DAWNBRINGER(AnimationData.MAGIC_STANDARD_WAVE_STAFF,  Projectiles(1544, 1547),22516), // https://oldschool.runescape.wiki/w/Dawnbringer
-    WEAPON_HARM(Set.of(AnimationData.MAGIC_STANDARD_WAVE_STAFF, AnimationData.MAGIC_STANDARD_STRIKE_BOLT_BLAST_STAFF, AnimationData.MAGIC_STANDARD_SURGE_STAFF),
+    WEAPON_HARM(Set.of(
+            AnimationData.MAGIC_STANDARD_STRIKE_STAFF,
+            AnimationData.MAGIC_STANDARD_WAVE_STAFF,
+            AnimationData.MAGIC_STANDARD_STRIKE_BOLT_BLAST_STAFF,
+            AnimationData.MAGIC_STANDARD_SURGE_STAFF
+        ),
         Projectiles(/*in level order then air -> fire*/
             91, 94, 97, 100, /* strikes */
             118, 121, 124, 127, /* bolts */
             133, 136, 139, 130, /* blasts */
             159, 162, 165, 156, /* waves */
             1456, 1459, 1462, 1465 /* surges */),
-        24508), // https://oldschool.runescape.wiki/w/Harmonised_nightmare_staff
+        24423), // https://oldschool.runescape.wiki/w/Harmonised_nightmare_staff
     WEAPON_RED_C_STAFF_A(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1723), 23853), // https://oldschool.runescape.wiki/w/Corrupted_staff_(attuned)
     WEAPON_RED_C_STAFF_B(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1723), 23852), // https://oldschool.runescape.wiki/w/Corrupted_staff_(basic)
     WEAPON_RED_C_STAFF_P(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1723), 23854), // https://oldschool.runescape.wiki/w/Corrupted_staff_(perfected)


### PR DESCRIPTION
Fixes #106.

This definitely used to work, I figure out what changed:

* the item ID changed `24508` => `24423`
* the strike animation data has also changed

Spell | Image
------|------
Strike (changed)|<img width="486" height="351" alt="strike" src="https://github.com/user-attachments/assets/39b7f805-9a04-4318-b962-ee348d6303b8" />
Bolt (unchanged)|<img width="522" height="343" alt="bolt" src="https://github.com/user-attachments/assets/2042863f-ddd9-4bd9-b7bc-6470d0b1de0c" />
Blast (unchanged)|<img width="476" height="336" alt="blast" src="https://github.com/user-attachments/assets/cbe5cf41-8421-40ea-92d7-896e3bfc61aa" />
Wave (unchanged) |<img width="483" height="377" alt="wave" src="https://github.com/user-attachments/assets/df77ddfa-c3e8-4621-86ef-35b5c50c215e" />
Surge (unchanged)|<img width="473" height="290" alt="surge" src="https://github.com/user-attachments/assets/199a6b49-dd82-4edb-b18d-3be95f5f85e4" />


## Testing


https://github.com/user-attachments/assets/d56cf9e3-d91b-4996-8c7a-2a50d70e7c9b

