### PR TITLE
Add more non-attack animations

### DIFF
--- a/src/main/java/com/attacktimer/AnimationData.java
+++ b/src/main/java/com/attacktimer/AnimationData.java
@@ -224,6 +224,9 @@ public enum AnimationData
     FLECTHING_CHISEL(5244, AttackStyle.NON_ATTACK), // chisel & moonlight antler
     FLECTHING_DART_TIP(8485, AttackStyle.NON_ATTACK), // dart tip & feather
     HERB_TAR(5249, AttackStyle.NON_ATTACK), // pestle motar animation
+    SETUP_HUNTER_TRAP(5208, AttackStyle.NON_ATTACK),
+    RESET_SNARE_TRAP(5207, AttackStyle.NON_ATTACK),
+    RESET_BOX_TRAP(5212, AttackStyle.NON_ATTACK),
 
     DESERT_AMMY(3872, AttackStyle.NON_ATTACK),
 


### PR DESCRIPTION
## Summary

Fixes some of #116:

* Unfortunately garg smash (and thrown hammer) is animation id `401` (crush weapons in general) so that's a won't fix.
* Throwing fishing explosives is `929` (thrown weapons) so that's another won't fix.

Adding these animations should make the plugin more reliable for rockslugs and dessert lizards, whilst tick manipulating (e.g. chins), or multi-skilling (fletching darts).

## Testing

Test still pass so no duplicated IDs were added.
```
> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

BUILD SUCCESSFUL in 5s
```

Tick manip:


https://github.com/user-attachments/assets/d5b2b04a-f60b-4863-9416-12f36b93bbda



Hunter trap delay:

https://github.com/user-attachments/assets/34901c6f-ab99-454b-9d59-59c0e56f42d5

