### PR TITLE
Fix Overlay Throwing Errors

### DIFF
--- a/src/main/java/com/attacktimer/AttackTimerBarOverlay.java
+++ b/src/main/java/com/attacktimer/AttackTimerBarOverlay.java
@@ -107,8 +107,8 @@ class AttackTimerBarOverlay extends Overlay
         int numerMod = (config.barFills()) ? 1 : 0;
         float ratio = (float) (plugin.getTicksUntilNextAttack() - numerMod) / (float) (plugin.getWeaponPeriod() - denomMod);
         // barDirection:
-        // true  -> drain -> moves right to left each tick
-        // false -> fills -> move left to right each tick
+        // true  -> drain -> moves right to left  each tick
+        // false -> fills -> move  left  to right each tick
         ratio = config.barDirection() ? clampBetween0and1(ratio) : clampBetween0and1(1.0f - ratio);
 
         AttackBarStyle barStyle = config.barStyle();
@@ -128,7 +128,7 @@ class AttackTimerBarOverlay extends Overlay
             // if progress is less than 1 then there's no "sub-bar" to draw as it would either have fractional
             // pixels (not possible) or negative pixels (also not possible) fixes
             // (https://github.com/ngraves95/attacktimer/issues/92)
-            if (progressFill <= 1)
+            if (progressFill < 1)
             {
                 return null;
             }


### PR DESCRIPTION
## Summary

As reported by https://github.com/ngraves95/attacktimer/issues/92 (but I personally didn't encounter until https://github.com/ngraves95/attacktimer/pull/87 was merged) when the HD bar is empty it will spam the logs with exceptions.

Looking at what causes this it's two things:

* When the bar is nearly empty:
  * Ratio can be negative depending on the settings
  * If the ratio is negative then negative pixels are requested for the sub image
* When the bar is actually empty:
  * `progressFill` is `0`  which asks for a 0 width sub image

Therefore to make the code more robust `ratio` is always clamped between `0` and `1`. And when `progressFill` is less than or equal to `1` we should just not draw the second image. (which was what was already happening if you think about because the exception is complaining it can't draw an image).

-----

Aside: updated the copyright (git history) and formatting of the file.

## Testing

A minute of gargoyle killing flicking through the settings showing the RL logs and the lack of spam :)

https://www.youtube.com/watch?v=WBdZh-M7X_c