### PR TITLE
Add setting for zero-based tick counting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,14 +48,6 @@ tasks.withType(JavaCompile) {
 	options.release.set(11)
 }
 
-tasks.register('run', JavaExec) {
-    classpath = sourceSets.test.runtimeClasspath
-    mainClass = "com.attacktimer.AttackTimerPluginTest"
-
-    jvmArgs "-ea"
-    args "--developer-mode", "--debug"
-}
-
 // Code based on
 // https://gist.github.com/lwasyl/6ae0b8a66903729033e18ffc7a503597#file-fancy_logging_original-gradle
 tasks.withType(Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,14 @@ tasks.withType(JavaCompile) {
 	options.release.set(11)
 }
 
+tasks.register('run', JavaExec) {
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = "com.attacktimer.AttackTimerPluginTest"
+
+    jvmArgs "-ea"
+    args "--developer-mode", "--debug"
+}
+
 // Code based on
 // https://gist.github.com/lwasyl/6ae0b8a66903729033e18ffc7a503597#file-fancy_logging_original-gradle
 tasks.withType(Test) {

--- a/src/main/java/com/attacktimer/AttackTimerMetronomeConfig.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomeConfig.java
@@ -156,6 +156,18 @@ public interface AttackTimerMetronomeConfig extends Config
 		return 0;
 	}
 
+    @ConfigItem(
+            position = 9,
+            keyName = "useZeroBasedTickCount",
+            name = "Zero-based Tick Count",
+            description = "Count ticks to 0 instead of 1",
+            section = TickNumberSettings
+    )
+    default boolean useZeroBasedTickCount()
+    {
+        return false;
+    }
+
 	@ConfigSection(
 			name = "Attack Bar",
 			description = "Change the colors and number of colors to cycle through",

--- a/src/main/java/com/attacktimer/AttackTimerMetronomeTileOverlay.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomeTileOverlay.java
@@ -118,7 +118,8 @@ public class AttackTimerMetronomeTileOverlay extends Overlay
                     break;
             }
             if (playerPoint != null) {
-                OverlayUtil.renderTextLocation(graphics, playerPoint, String.valueOf(ticksRemaining), ticksRemaining == 1 ? config.LastColor() : config.NumberColor());
+                int displayTicksRemaining = config.useZeroBasedTickCount() ? ticksRemaining - 1 : ticksRemaining;
+                OverlayUtil.renderTextLocation(graphics, playerPoint, String.valueOf(displayTicksRemaining), ticksRemaining == 1 ? config.LastColor() : config.NumberColor());
             }
         }
         return null;


### PR DESCRIPTION
## Summary

This change adds a setting to use zero-based tick counts for the tile display.

This means that for a 3-tick weapon, the count will be `2-1-0-2-1-0` instead of `3-2-1-3-2-1`.

The reason for adding this is that this is more intuitive for prayer flicking, where the count can be interpreted as "amount of ticks before you should enable prayers for the next attack"

## Testing

Tested with zero-based enabled and disabled, tested the number counter as well as the bar and both combined.

Settings:

![plugin-settings](https://github.com/user-attachments/assets/021730fd-da60-4c93-9107-0f3df944b299)

Zero-based counting disabled:

![disabled](https://github.com/user-attachments/assets/0064ba5c-ffd1-4ee3-a580-099b077b9f64)

Zero-based counting enabled:

![enabled](https://github.com/user-attachments/assets/3d8ea2a0-09ba-456d-bfe4-cb9545bdbb90)

Zero-based counting enabled, as well as the bar enabled:

![enabled_with_bar](https://github.com/user-attachments/assets/bc708f6e-4440-49f9-9046-685694d96229)
