### PR TITLE
Leagues: Add animation for Infernal Tecpatl

### DIFF
--- a/src/main/java/com/attacktimer/AnimationData.java
+++ b/src/main/java/com/attacktimer/AnimationData.java
@@ -128,6 +128,7 @@ public enum AnimationData
     MELEE_SARA_SWORD_SPEC(1132, AttackStyle.MELEE, true), // https://oldschool.runescape.wiki/w/Saradomin_sword assumed to be the same for the blessed version
     MELEE_RED_KERIS_SPEC(9544, AttackStyle.MELEE, true), // https://oldschool.runescape.wiki/w/Keris_partisan_of_corruption
     MELEE_SALAMANDER(5247, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Salamander
+    MELEE_INFERNAL_TECPATL(12342, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Infernal_tecpatl
 
     // RANGED
     RANGED_CHINCHOMPA(7618, AttackStyle.RANGED),


### PR DESCRIPTION
## Summary

Fixes #134

According to @sergentfire66-OSRS https://github.com/ngraves95/attacktimer/issues/134#issuecomment-4290154020 testing the animation for the weapon is `12342`, I think adding this should resolve the problem, hopefully the stats are correct. Otherwise we'll need an exception like twinflame.

## Testing

Not playing leagues so can't test, just gonna do it live.