### PR TITLE
fix build again

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,5 +1,6 @@
 displayName=AttackTimer
 author=ngraves95,Lexer747
+build=standard
 description=A plugin to countdown until your next attack
 tags=pvm,timer,attack,combat,weapon
 plugins=com.attacktimer.AttackTimerMetronomePlugin


### PR DESCRIPTION
Seems like some new requirements were added for plugins, we don't use any fancy build steps so `standard` seems good for us. https://github.com/runelite/plugin-hub#build-type

https://github.com/runelite/plugin-hub/actions/runs/24955126853/job/73071929053?pr=11645