### PR TITLE
fix: Venator Bow with Kit

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,7 +1,7 @@
 displayName=AttackTimer
 author=ngraves95,Lexer747
 build=standard
-version=1.2.2
+version=1.2.3
 description=A plugin to countdown until your next attack
 tags=pvm,timer,attack,combat,weapon
 plugins=com.attacktimer.AttackTimerMetronomePlugin

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -676,7 +676,7 @@ public class AttackTimerMetronomePlugin extends Plugin
 
     public void checkForLateWeaponSwaps()
     {
-        final boolean weaponMisMatch = Utils.getWeaponId(client) != lastUsedWeaponId;
+        final boolean weaponMisMatch = getWeaponId() != lastUsedWeaponId;
 
         // This windowing safe guards of from late swaps inside a tick, if we have already rendered the tick
         // then we shouldn't perform another attack.


### PR DESCRIPTION
## Summary

In #141 and #144 I re-factored the late attack window stuff, I forgot that the venny bow had this ID workaround, but the plugin already has a method I should just use instead of the client utils.

Fixes https://github.com/ngraves95/attacktimer/issues/149

## Testing

https://github.com/user-attachments/assets/0d197cc6-4891-4e86-b48c-58df9b5270eb

