### PR TITLE
Fix dragon crossbow for LMS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -150,6 +150,7 @@ public class AttackTimerMetronomePlugin extends Plugin
     private static final int ECHO_VENATOR_BOW_WEAPON_ID = 30434;
     private static final int VENATOR_BOW_WEAPON_ID = 27610;
     private static final int BLACK_GEM_KERIS_ID = 30891; // https://oldschool.runescape.wiki/w/Keris_partisan_of_amascut
+    private static final int DRAGON_CROSSBOW_LMS_ID = 33460; // https://oldschool.runescape.wiki/w/Dragon_crossbow_(Last_Man_Standing)
 
     // Add other weapons here if in the Runelite dev shell this prints a different value to it's actual speed:
     //
@@ -158,6 +159,7 @@ public class AttackTimerMetronomePlugin extends Plugin
     private static final Map<Integer, Integer> NON_STANDARD_ATTACK_SPEEDS =
             new ImmutableMap.Builder<Integer, Integer>()
                     .put(BLACK_GEM_KERIS_ID, 4)
+                    .put(DRAGON_CROSSBOW_LMS_ID, 6)
                     .build();
 
     // These animations are the ones which exceed the duration of their attack cooldown


### PR DESCRIPTION
## Summary

In the runelite shell:
```
log.info("Dragon crossbow (Last Man Standing) {}", itemManager.getItemStats(33460).getEquipment().getAspeed());
```

Currently errors with a null pointer exception.

Fixes #154 

## Testing

Cbow is working again.

https://github.com/user-attachments/assets/17ceefe6-b005-4413-af10-6cc3207a3cd7

