### PR TITLE
Blood Moon Rises

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Ticks until next attack may be enabled over your player's head.
 
 ## Updates
 
+## 1.2.5
+
+* Blood moon rises support (Hallowed Flail, Sunspear)
+* Dragon crossbow in LMS
+* Venator Bow Kit
+
 ## 1.2
 
 Overlay improvements!

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,7 +1,7 @@
 displayName=AttackTimer
 author=ngraves95,Lexer747
 build=standard
-version=1.2.4
+version=1.2.5
 description=A plugin to countdown until your next attack
 tags=pvm,timer,attack,combat,weapon
 plugins=com.attacktimer.AttackTimerMetronomePlugin

--- a/src/main/java/com/attacktimer/AnimationData.java
+++ b/src/main/java/com/attacktimer/AnimationData.java
@@ -129,6 +129,7 @@ public enum AnimationData
     MELEE_RED_KERIS_SPEC(9544, AttackStyle.MELEE, true), // https://oldschool.runescape.wiki/w/Keris_partisan_of_corruption
     MELEE_SALAMANDER(5247, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Salamander
     MELEE_INFERNAL_TECPATL(12342, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Infernal_tecpatl
+    MELEE_HALLOWED_FLAIL(14244, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Hallowed_flail
 
     // RANGED
     RANGED_CHINCHOMPA(7618, AttackStyle.RANGED),

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -151,6 +151,7 @@ public class AttackTimerMetronomePlugin extends Plugin
     private static final int VENATOR_BOW_WEAPON_ID = 27610;
     private static final int BLACK_GEM_KERIS_ID = 30891; // https://oldschool.runescape.wiki/w/Keris_partisan_of_amascut
     private static final int DRAGON_CROSSBOW_LMS_ID = 33460; // https://oldschool.runescape.wiki/w/Dragon_crossbow_(Last_Man_Standing)
+    private static final int SUNSPEAR_ID = 33722; // https://oldschool.runescape.wiki/w/Sunspear
 
     // Add other weapons here if in the Runelite dev shell this prints a different value to it's actual speed:
     //
@@ -160,6 +161,7 @@ public class AttackTimerMetronomePlugin extends Plugin
             new ImmutableMap.Builder<Integer, Integer>()
                     .put(BLACK_GEM_KERIS_ID, 4)
                     .put(DRAGON_CROSSBOW_LMS_ID, 6)
+                    .put(SUNSPEAR_ID, 5)
                     .build();
 
     // These animations are the ones which exceed the duration of their attack cooldown

--- a/src/main/java/com/attacktimer/WeaponType.java
+++ b/src/main/java/com/attacktimer/WeaponType.java
@@ -89,7 +89,12 @@ public enum WeaponType
     BULWARK(CRUSH, CRUSH, null, CRUSH),
     POWERED_WAND(CRUSH, null, null, NONE),
     PARTISAN(MAGIC, MAGIC, null, MAGIC),
-    PARTISAN_2(STAB, STAB, CRUSH, STAB);
+    PARTISAN_2(STAB, STAB, CRUSH, STAB), // 30
+    PLACE_HOLDER_0(null, null, null), // 31
+    PLACE_HOLDER_1(null, null, null), // 32
+    PLACE_HOLDER_2(null, null, null), // 33
+    PLACE_HOLDER_3(null, null, null), // 34
+    FLAIL(SLASH, SLASH, null, SLASH); // 35
 
     private static final Map<Integer, WeaponType> WEAPON_TYPES;
 


### PR DESCRIPTION
## Summary

Fixes all the problems I found in https://github.com/ngraves95/attacktimer/issues/160

* Sunspear causes a null pointer exception when looked up with the Runelite API so it's added to the `NON_STANDARD_ATTACK_SPEEDS` list.
* Flail:
  * null pointer exceptions because it looks like Jagex added more `WeaponType` enums this was index `35` but we previously only had `31`.
  * The animation data was added but I suspect the null pointer fix is the only bit needed.

## Testing

https://github.com/user-attachments/assets/a2f3ee56-227c-498f-b779-32fed660f196

