### PR TITLE
Trident Ornment Kits new IDs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 }
 
 def runeLiteVersion = 'latest.release'
+def pluginMainClass = 'com.example.AttackTimerPluginTest'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -55,6 +56,32 @@ tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 	options.release.set(11)
 	options.compilerArgs += ['-Xlint:deprecation']
+}
+
+tasks.register('shadowJar', Jar) {
+	dependsOn configurations.testRuntimeClasspath
+	manifest {
+		attributes('Main-Class': pluginMainClass, 'Multi-Release': true)
+	}
+
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+	from sourceSets.main.output
+	from sourceSets.test.output
+	from {
+		configurations.testRuntimeClasspath.collect { file ->
+			file.isDirectory() ? file : zipTree(file)
+		}
+	}
+
+	exclude 'META-INF/INDEX.LIST'
+	exclude 'META-INF/*.SF'
+	exclude 'META-INF/*.DSA'
+	exclude 'META-INF/*.RSA'
+	exclude '**/module-info.class'
+
+	group = BasePlugin.BUILD_GROUP
+	archiveClassifier.set('shadow')
+	archiveFileName.set("${rootProject.name}-${project.version}-all.jar")
 }
 
 // Code based on

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,7 +1,7 @@
 displayName=AttackTimer
 author=ngraves95,Lexer747
 build=standard
-version=1.2.5
+version=1.2.6
 description=A plugin to countdown until your next attack
 tags=pvm,timer,attack,combat,weapon
 plugins=com.attacktimer.AttackTimerMetronomePlugin

--- a/src/main/java/com/attacktimer/PoweredStaves.java
+++ b/src/main/java/com/attacktimer/PoweredStaves.java
@@ -67,11 +67,9 @@ public enum PoweredStaves
     WEAPON_SANG(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1539), 22323), // https://oldschool.runescape.wiki/w/Sanguinesti_staff#Charged
     WEAPON_SANG_KIT(AnimationData.MAGIC_STANDARD_WAVE_STAFF, 25731), // https://oldschool.runescape.wiki/w/Holy_sanguinesti_staff#Charged
     WEAPON_STARTER_STAFF(22335, 22336, 28557, 28558), // https://oldschool.runescape.wiki/w/Starter_staff TODO get the animation when DMM goes live
-    WEAPON_SWAMP(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1040),12899), // https://oldschool.runescape.wiki/w/Trident_of_the_swamp#Charged
-    WEAPON_SWAMP_E(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1252),22292), // https://oldschool.runescape.wiki/w/Trident_of_the_swamp_(e)#Charged
+    WEAPON_SWAMP(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1040), 12899, 22292, 33314, 33318), // https://oldschool.runescape.wiki/w/Trident_of_the_swamp
     WEAPON_THAMMARON(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(2340),22555, 22556), //https://oldschool.runescape.wiki/w/Thammaron%27s_sceptre
-    WEAPON_TRIDENT(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1252), 11907), // https://oldschool.runescape.wiki/w/Trident_of_the_seas#Partially_charged
-    WEAPON_TRIDENT_E(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1252),22288), // https://oldschool.runescape.wiki/w/Trident_of_the_seas_(e)#Charged
+    WEAPON_TRIDENT(AnimationData.MAGIC_STANDARD_WAVE_STAFF, Projectiles(1252), 11905, 11907, 22288, 33322, 33323, 33326), // https://oldschool.runescape.wiki/w/Trident_of_the_seas
     WEAPON_WARPED_SCEPTRE(AnimationData.MAGIC_WARPED_SCEPTRE, 28585, 28586); // https://oldschool.runescape.wiki/w/Warped_sceptre
 
     @Getter


### PR DESCRIPTION
## Summary

Adds new IDs for other trident variations https://oldschool.runescape.wiki/w/Item_IDs

This also adds the shadowjar target from the example plugin https://github.com/runelite/example-plugin/blob/master/build.gradle#L45.

Fixes #162

## Testing

Bought my own kit, seems to work fine :) 

https://github.com/user-attachments/assets/b0bf7a8e-357e-435a-9f72-90b22e8e1142

