### PR TITLE
Support Stymphike Tartare

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ticks until next attack may be enabled over your player's head.
 * Blood moon rises support (Hallowed Flail, Sunspear) - Stymphike Tartare
 * Dragon crossbow in LMS
 * Venator Bow Kit
+* Demonic Pacts trident Kits
 
 ## 1.2
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Ticks until next attack may be enabled over your player's head.
 
 ## Updates
 
-## 1.2.5
+## 1.2.5 - 1.2.7
 
-* Blood moon rises support (Hallowed Flail, Sunspear)
+* Blood moon rises support (Hallowed Flail, Sunspear) - Stymphike Tartare
 * Dragon crossbow in LMS
 * Venator Bow Kit
 

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,7 +1,7 @@
 displayName=AttackTimer
 author=ngraves95,Lexer747
 build=standard
-version=1.2.6
+version=1.2.7
 description=A plugin to countdown until your next attack
 tags=pvm,timer,attack,combat,weapon
 plugins=com.attacktimer.AttackTimerMetronomePlugin

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -463,12 +463,13 @@ public class AttackTimerMetronomePlugin extends Plugin
 
 
     private static final String GENERIC_EAT = "You eat";
+    private static final String VAMPYRIUM_EAT = "Your stomach doesn't like it... but it heals some health"; // https://oldschool.runescape.wiki/w/Stymphike_tartare
     private static final String BARBARIAN_POTIONS = "You drink the lumpy potion"; // barbarian potions https://oldschool.runescape.wiki/w/Barbarian_Training#Barbarian_potions
     private static final String JUG_OF_WINE = "You drink the wine"; // Wine https://oldschool.runescape.wiki/w/Jug_of_wine
 
     // Match only the start of the line with `^` and the Pattern.MULTILINE
     private static final Pattern EAT_MESSAGE = Pattern
-            .compile("^(" + GENERIC_EAT + "|" + BARBARIAN_POTIONS + "|" + JUG_OF_WINE + ")", Pattern.MULTILINE & Pattern.CASE_INSENSITIVE);
+            .compile("^(" + GENERIC_EAT + "|" + BARBARIAN_POTIONS + "|" + JUG_OF_WINE + "|" + VAMPYRIUM_EAT + ")", Pattern.MULTILINE & Pattern.CASE_INSENSITIVE);
 
     // gnome foods are also fast eats (Note these are not the food names as the wiki lists them, but the name
     // as written in chat), also pre-made and handmade have the same chat message.

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -494,7 +494,7 @@ public class AttackTimerMetronomePlugin extends Plugin
 
         if (EAT_MESSAGE.matcher(message).find())
         {
-            int attackDelay = DEFAULT_FOOD_ATTACK_DELAY_TICKS;
+            int attackDelay;
             if (FAST_EAT.matcher(message).find())
             {
                 attackDelay = FAST_EAT_ATTACK_DELAY_TICKS;
@@ -502,6 +502,10 @@ public class AttackTimerMetronomePlugin extends Plugin
             else if (SLOW_FOOD.matcher(message).find())
             {
                 attackDelay = SLOW_FOOD_ATTACK_DELAY_TICKS;
+            }
+            else
+            {
+                attackDelay = DEFAULT_FOOD_ATTACK_DELAY_TICKS;
             }
 
             // We should always add eat delay

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -189,6 +189,7 @@ public class AttackTimerMetronomePlugin extends Plugin
 
     // https://oldschool.runescape.wiki/w/Food/Fast_foods#Food_Delays
     // These constants are not to be confused with eat delay.
+    private final int SLOW_FOOD_ATTACK_DELAY_TICKS = 4;
     private final int DEFAULT_FOOD_ATTACK_DELAY_TICKS = 3;
     private final int FAST_EAT_ATTACK_DELAY_TICKS = 2;
 
@@ -463,6 +464,7 @@ public class AttackTimerMetronomePlugin extends Plugin
 
 
     private static final String GENERIC_EAT = "You eat";
+    // unfortunately you don't get any message when full HP
     private static final String VAMPYRIUM_EAT = "Your stomach doesn't like it... but it heals some health"; // https://oldschool.runescape.wiki/w/Stymphike_tartare
     private static final String BARBARIAN_POTIONS = "You drink the lumpy potion"; // barbarian potions https://oldschool.runescape.wiki/w/Barbarian_Training#Barbarian_potions
     private static final String JUG_OF_WINE = "You drink the wine"; // Wine https://oldschool.runescape.wiki/w/Jug_of_wine
@@ -470,6 +472,11 @@ public class AttackTimerMetronomePlugin extends Plugin
     // Match only the start of the line with `^` and the Pattern.MULTILINE
     private static final Pattern EAT_MESSAGE = Pattern
             .compile("^(" + GENERIC_EAT + "|" + BARBARIAN_POTIONS + "|" + JUG_OF_WINE + "|" + VAMPYRIUM_EAT + ")", Pattern.MULTILINE & Pattern.CASE_INSENSITIVE);
+
+    //
+    private static final Pattern SLOW_FOOD = Pattern
+            .compile("^(" + VAMPYRIUM_EAT + ")", Pattern.MULTILINE & Pattern.CASE_INSENSITIVE);
+
 
     // gnome foods are also fast eats (Note these are not the food names as the wiki lists them, but the name
     // as written in chat), also pre-made and handmade have the same chat message.
@@ -487,9 +494,15 @@ public class AttackTimerMetronomePlugin extends Plugin
 
         if (EAT_MESSAGE.matcher(message).find())
         {
-            int attackDelay = FAST_EAT.matcher(message).find() ?
-                      FAST_EAT_ATTACK_DELAY_TICKS
-                    : DEFAULT_FOOD_ATTACK_DELAY_TICKS;
+            int attackDelay = DEFAULT_FOOD_ATTACK_DELAY_TICKS;
+            if (FAST_EAT.matcher(message).find())
+            {
+                attackDelay = FAST_EAT_ATTACK_DELAY_TICKS;
+            }
+            else if (SLOW_FOOD.matcher(message).find())
+            {
+                attackDelay = SLOW_FOOD_ATTACK_DELAY_TICKS;
+            }
 
             // We should always add eat delay
             pendingEatDelayTicks += attackDelay;


### PR DESCRIPTION
## Summary

https://oldschool.runescape.wiki/w/Stymphike_tartare doesn't use the normal eat message (or a normal eat delay).

<img width="422" height="28" alt="image" src="https://github.com/user-attachments/assets/597fa738-de3c-446c-91be-a6e63b47d453" />

This PR adds the new message and new 4 tick eat delay.

Progress on #160

## Testing

BTW tested the kirsten (and spec) it works just fine.

https://github.com/user-attachments/assets/0c5b861b-7471-41db-ac94-51488d8856d9

OLD (3t delay):
https://github.com/user-attachments/assets/c7b4395b-ef18-4e21-8f4a-092f12a44d98

