### PR TITLE
Improve `isPlayerAttacking` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,18 @@ Ticks until next attack may be enabled over your player's head.
 
 ## Updates
 
-## 1.2.5 - 1.2.7
+## 1.2.8
+
+* Fix regression in 1.1, greater corruption triggering cooldown
+
+## 1.2.3 - 1.2.7
 
 * Blood moon rises support (Hallowed Flail, Sunspear) - Stymphike Tartare
 * Dragon crossbow in LMS
 * Venator Bow Kit
 * Demonic Pacts trident Kits
 
-## 1.2
+## 1.2.0
 
 Overlay improvements!
 

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,7 +1,7 @@
 displayName=AttackTimer
 author=ngraves95,Lexer747
 build=standard
-version=1.2.7
+version=1.2.8
 description=A plugin to countdown until your next attack
 tags=pvm,timer,attack,combat,weapon
 plugins=com.attacktimer.AttackTimerMetronomePlugin

--- a/src/main/java/com/attacktimer/AnimationData.java
+++ b/src/main/java/com/attacktimer/AnimationData.java
@@ -130,6 +130,7 @@ public enum AnimationData
     MELEE_SALAMANDER(5247, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Salamander
     MELEE_INFERNAL_TECPATL(12342, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Infernal_tecpatl
     MELEE_HALLOWED_FLAIL(14244, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Hallowed_flail
+    MELEE_FELLING_AXE(10079, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Crystal_felling_axe
 
     // RANGED
     RANGED_CHINCHOMPA(7618, AttackStyle.RANGED),

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -125,6 +125,7 @@ public class AttackTimerMetronomePlugin extends Plugin
 
     private Spellbook currentSpellBook = Spellbook.STANDARD;
     private int lastUsedWeaponId = -1;
+    private Actor lastTarget = null;
     private int soundEffectTick = -1;
     private int soundEffectId = -1;
     private boolean isUsingMagic = false;
@@ -385,26 +386,27 @@ public class AttackTimerMetronomePlugin extends Plugin
 
     private boolean isPlayerAttacking()
     {
-        int animationId = client.getLocalPlayer().getAnimation();
+        final Player localPlayer = client.getLocalPlayer();
+        final int animationId = localPlayer.getAnimation();
         if (AnimationData.isBlockListAnimation(animationId))
         {
             return false;
         }
 
-        // Not walking is either any player animation or the edge cases which don't trigger an animation, e.g Salamander.
-        boolean notWalking = animationId != -1 || getSalamanderAttack();
+        // Not walking is either ANY player animation or the edge cases which don't trigger an animation, e.g Salamander.
+        final boolean notWalking = animationId != -1 || getSalamanderAttack();
 
         // Testing if we are attacking by checking the target is more future
         // proof to new weapons which don't need custom code and the weapon
         // stats are enough.
-        Actor target = client.getLocalPlayer().getInteracting();
+        final Actor target = localPlayer.getInteracting();
         if (target != null && (target instanceof NPC))
         {
             final NPC npc = (NPC) target;
-            boolean containsAttackOption = Arrays.stream(npc.getComposition().getActions()).anyMatch("Attack"::equals);
-            Integer health = npcManager.getHealth(npc.getId());
-            boolean hasHealthAndLevel = health != null && health > 0 && target.getCombatLevel() > 0;
-            boolean attackingNPC = hasHealthAndLevel || SPECIAL_NPCS.contains(npc.getId()) || containsAttackOption;
+            final boolean containsAttackOption = Arrays.stream(npc.getComposition().getActions()).anyMatch("Attack"::equals);
+            final Integer health = npcManager.getHealth(npc.getId());
+            final boolean hasHealthAndLevel = health != null && health > 0 && target.getCombatLevel() > 0;
+            final boolean attackingNPC = hasHealthAndLevel || SPECIAL_NPCS.contains(npc.getId()) || containsAttackOption;
             // just having a target is not enough the player may be out of range, we must wait for any
             // animation which isn't running/walking/etc
             return attackingNPC && notWalking;
@@ -413,9 +415,14 @@ public class AttackTimerMetronomePlugin extends Plugin
         {
             return notWalking;
         }
+        if (target == null)
+        {
+            // Not attacking anything
+            return false;
+        }
 
-        AnimationData fromId = AnimationData.fromId(animationId);
         // Do not use any animations from this set
+        final AnimationData fromId = AnimationData.fromId(animationId);
         if (UNRELIABLE_ANIMATIONS.contains(fromId))
         {
             return false;
@@ -432,8 +439,8 @@ public class AttackTimerMetronomePlugin extends Plugin
         // to detect this type of attack as a cast, only sound is an indication that the player is on
         // cooldown, melee attacks, etc will trigger an animation overwriting the last frame of the blowpipe's
         // idle animation.
-        boolean castingFromSound = client.getTickCount() == soundEffectTick ? CastingSoundData.isCastingSound(soundEffectId) : false;
-        boolean castingFromAnimation = AnimationData.isManualCasting(curId);
+        final boolean castingFromSound = client.getTickCount() == soundEffectTick ? CastingSoundData.isCastingSound(soundEffectId) : false;
+        final boolean castingFromAnimation = AnimationData.isManualCasting(curId);
         return castingFromSound || castingFromAnimation;
     }
 
@@ -443,6 +450,7 @@ public class AttackTimerMetronomePlugin extends Plugin
         setAttackDelay();
         tickPeriod = attackDelayHoldoffTicks;
         uiHideDebounceTickCount = UI_HIDE_DEBOUNCE_TICKS_MAX;
+        lastTarget = client.getLocalPlayer().getInteracting();
     }
 
     public int getTicksUntilNextAttack()
@@ -667,6 +675,7 @@ public class AttackTimerMetronomePlugin extends Plugin
         sb.append("attackDelayHoldoffTicks: "); sb.append(this.attackDelayHoldoffTicks);sb.append(SEPARATOR);
         sb.append("attackState: "); sb.append(this.attackState);sb.append(SEPARATOR);
         sb.append("renderedState: "); sb.append(this.renderedState);sb.append(SEPARATOR);
+        sb.append("lastTarget: "); sb.append(this.lastTarget == null ? "null" : this.lastTarget.getName());sb.append("\n");
         sb.append("pendingEatDelayTicks: "); sb.append(this.pendingEatDelayTicks);sb.append(SEPARATOR);
         sb.append("currentSpellBook: "); sb.append(this.currentSpellBook);sb.append(SEPARATOR);
         sb.append("soundEffectTick: "); sb.append(this.soundEffectTick);sb.append(SEPARATOR);
@@ -680,8 +689,7 @@ public class AttackTimerMetronomePlugin extends Plugin
 
     public void onRender()
     {
-        int delta = 0;
-        delta = VariableSpeed.SHADOW_CRASH.onRender(client, attackDelayHoldoffTicks, isUsingMagic, config.debugLogs());
+        final int delta = VariableSpeed.SHADOW_CRASH.onRender(client, attackDelayHoldoffTicks, isUsingMagic, config.debugLogs());
 
         if (delta != 0)
         {
@@ -701,7 +709,8 @@ public class AttackTimerMetronomePlugin extends Plugin
         final boolean weaponMisMatch = getWeaponId() != lastUsedWeaponId;
 
         // This windowing safe guards of from late swaps inside a tick, if we have already rendered the tick
-        // then we shouldn't perform another attack.
+        // then we shouldn't perform another attack. We don't need to check for a valid target
+        // (isPlayerAttacking) as this must have already been check to be in `DELAYED_FIRST_TICK`
         if (inPreAttackWindow() && weaponMisMatch)
         {
             logStateTrace("checkForLateWeaponSwaps");

--- a/src/test/java/com/attacktimer/EatTest.java
+++ b/src/test/java/com/attacktimer/EatTest.java
@@ -29,6 +29,8 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.when;
 
 import com.attacktimer.AttackTimerMetronomePlugin.AttackState;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Player;
 import net.runelite.api.events.ChatMessage;
@@ -73,5 +75,9 @@ public class EatTest extends IntegrationTests
             curEatDelayTicks += 2;
             assertSame(curEatDelayTicks, underTest.pendingEatDelayTicks);
         }
+        // We don't care about this output for the test but want the mock to be happy this test is actually
+        // fetching the state.
+        ByteArrayDataOutput channel = ByteStreams.newDataOutput();
+        underTest.writeState(channel);
     }
 }

--- a/src/test/java/com/attacktimer/IntegrationTests.java
+++ b/src/test/java/com/attacktimer/IntegrationTests.java
@@ -122,6 +122,7 @@ public class IntegrationTests
         when(mockedTarget.getComposition()).thenReturn(mockedCompositions);
         int mockedNpcId = 0xFFFF;
         when(mockedTarget.getId()).thenReturn(mockedNpcId);
+        when(mockedTarget.getName()).thenReturn("mockedNpc");
         String[] actions = {
                 "Attack", "Examine",
         };

--- a/src/test/java/com/attacktimer/testdata/PunishTest.txt
+++ b/src/test/java/com/attacktimer/testdata/PunishTest.txt
@@ -1,3 +1,6 @@
-tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 0, uiHideDebounceTickCount: -1, attackDelayHoldoffTicks: -1, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 0, uiHideDebounceTickCount: -1, attackDelayHoldoffTicks: -1, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1

--- a/src/test/java/com/attacktimer/testdata/PunishWastedTest.txt
+++ b/src/test/java/com/attacktimer/testdata/PunishWastedTest.txt
@@ -1,3 +1,6 @@
-tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 0, uiHideDebounceTickCount: -1, attackDelayHoldoffTicks: -1, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 0, uiHideDebounceTickCount: -1, attackDelayHoldoffTicks: -1, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1

--- a/src/test/java/com/attacktimer/testdata/PunishWastedWrongStyleTest.txt
+++ b/src/test/java/com/attacktimer/testdata/PunishWastedWrongStyleTest.txt
@@ -1,3 +1,6 @@
-tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 0, uiHideDebounceTickCount: -1, attackDelayHoldoffTicks: -1, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 8, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 7, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 0, uiHideDebounceTickCount: -1, attackDelayHoldoffTicks: -1, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 8, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 7, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1

--- a/src/test/java/com/attacktimer/testdata/basicTest.txt
+++ b/src/test/java/com/attacktimer/testdata/basicTest.txt
@@ -1,37 +1,69 @@
-tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] 1. Start by setting up the player and plugin
 [TEST MESSAGE] 2. Mock an attack animation
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] 3. Check that the plugin has registered the attack
 [TEST MESSAGE] 4. Check that the plugin counts down correctly
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 2, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 1, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 0, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 2, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 1, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 0, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] 5. Check that the plugin is back to a waiting state and it still counts down
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: -1, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: -2, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -1, attackDelayHoldoffTicks: -3, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -2, attackDelayHoldoffTicks: -4, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -3, attackDelayHoldoffTicks: -5, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -4, attackDelayHoldoffTicks: -6, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -5, attackDelayHoldoffTicks: -7, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -6, attackDelayHoldoffTicks: -8, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -7, attackDelayHoldoffTicks: -9, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -8, attackDelayHoldoffTicks: -10, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -9, attackDelayHoldoffTicks: -11, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -10, attackDelayHoldoffTicks: -12, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -11, attackDelayHoldoffTicks: -13, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -12, attackDelayHoldoffTicks: -14, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -13, attackDelayHoldoffTicks: -15, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -14, attackDelayHoldoffTicks: -16, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -15, attackDelayHoldoffTicks: -17, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -16, attackDelayHoldoffTicks: -18, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -17, attackDelayHoldoffTicks: -19, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -18, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -19, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: -1, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: -2, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -1, attackDelayHoldoffTicks: -3, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -2, attackDelayHoldoffTicks: -4, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -3, attackDelayHoldoffTicks: -5, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -4, attackDelayHoldoffTicks: -6, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -5, attackDelayHoldoffTicks: -7, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -6, attackDelayHoldoffTicks: -8, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -7, attackDelayHoldoffTicks: -9, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -8, attackDelayHoldoffTicks: -10, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -9, attackDelayHoldoffTicks: -11, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -10, attackDelayHoldoffTicks: -12, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -11, attackDelayHoldoffTicks: -13, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -12, attackDelayHoldoffTicks: -14, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -13, attackDelayHoldoffTicks: -15, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -14, attackDelayHoldoffTicks: -16, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -15, attackDelayHoldoffTicks: -17, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -16, attackDelayHoldoffTicks: -18, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -17, attackDelayHoldoffTicks: -19, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -18, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -19, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: -20, attackDelayHoldoffTicks: -20, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1

--- a/src/test/java/com/attacktimer/testdata/eatingFoodTest.txt
+++ b/src/test/java/com/attacktimer/testdata/eatingFoodTest.txt
@@ -1,21 +1,34 @@
-tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 0, uiHideDebounceTickCount: 0, attackDelayHoldoffTicks: 0, attackState: NOT_ATTACKING, renderedState: NOT_ATTACKING, lastTarget: null
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] 1. Start by setting up the player and plugin
 [TEST MESSAGE] 2. Mock an attack animation
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] 3. Check that the plugin has registered the attack
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] Perform an eat
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 3, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED_FIRST_TICK, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 3, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] Next game tick
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 5, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 5, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] Perform a fast eat
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 5, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 2, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 5, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 2, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] Next game tick
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 6, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 6, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
 [TEST MESSAGE] 4. Check that the plugin counts down correctly
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 5, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 4, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 2, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 1, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
-tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 0, attackState: DELAYED, renderedState: NOT_ATTACKING, pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 5, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 4, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 3, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 2, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 1, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1
+tickPeriod: 4, uiHideDebounceTickCount: 1, attackDelayHoldoffTicks: 0, attackState: DELAYED, renderedState: NOT_ATTACKING, lastTarget: mockedNpc
+pendingEatDelayTicks: 0, currentSpellBook: STANDARD, soundEffectTick: -1, soundEffectId: -1


### PR DESCRIPTION
## Summary

At some point in v1.1 when we switched to the allow any animation not explicitly blocked greater corruption could trigger the timer even with out a target.

Ensure target is not null when falling back to the animation data list (dark demon bane is in said list)

Fixes #151

(Also clean up the readme)

## Testing

https://github.com/user-attachments/assets/ed7d63bc-b81b-4eca-afd1-6a253fd789ad

