### PR TITLE
Fix for Wyrmscraig and Clean Workaround Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ Ticks until next attack may be enabled over your player's head.
 
 ## Updates
 
-## 1.2.8
+## 1.2.8 - 1.2.9
 
+* Fixes for Wyrmscraig (Hallowfell)
 * Fix regression in 1.1, greater corruption triggering cooldown
 
 ## 1.2.3 - 1.2.7
 
-* Blood moon rises support (Hallowed Flail, Sunspear) - Stymphike Tartare
+* Blood moon rises support (Hallowed Flail, Kisten, Sunspear) - Stymphike Tartare
 * Dragon crossbow in LMS
 * Venator Bow Kit
 * Demonic Pacts trident Kits

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,7 +1,7 @@
 displayName=AttackTimer
 author=ngraves95,Lexer747
 build=standard
-version=1.2.8
+version=1.2.9
 description=A plugin to countdown until your next attack
 tags=pvm,timer,attack,combat,weapon
 plugins=com.attacktimer.AttackTimerMetronomePlugin

--- a/src/main/java/com/attacktimer/AnimationData.java
+++ b/src/main/java/com/attacktimer/AnimationData.java
@@ -131,6 +131,7 @@ public enum AnimationData
     MELEE_INFERNAL_TECPATL(12342, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Infernal_tecpatl
     MELEE_HALLOWED_FLAIL(14244, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Hallowed_flail
     MELEE_FELLING_AXE(10079, AttackStyle.MELEE), // https://oldschool.runescape.wiki/w/Crystal_felling_axe
+    MELEE_HALLOWFELL(14470, AttackStyle.MELEE),
 
     // RANGED
     RANGED_CHINCHOMPA(7618, AttackStyle.RANGED),
@@ -259,6 +260,8 @@ public enum AnimationData
     TAKING_HIT_UNARMED(424, AttackStyle.NON_ATTACK),
     TAKING_HIT_VERACS_FLAIL(2063, AttackStyle.NON_ATTACK),
     TAKING_HIT_WHIP(1659, AttackStyle.NON_ATTACK),
+    TAKING_HIT_KISTEN(14257, AttackStyle.NON_ATTACK),
+    TAKING_HIT_HALLOWFELL(14472, AttackStyle.NON_ATTACK),
 
     LOW_ALCH(712, AttackStyle.NON_ATTACK),
     HIGH_ALCH(713, AttackStyle.NON_ATTACK);

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -150,9 +150,7 @@ public class AttackTimerMetronomePlugin extends Plugin
     private static final int TWINFLAME_STAFF_WEAPON_ID = 30634;
     private static final int ECHO_VENATOR_BOW_WEAPON_ID = 30434;
     private static final int VENATOR_BOW_WEAPON_ID = 27610;
-    private static final int BLACK_GEM_KERIS_ID = 30891; // https://oldschool.runescape.wiki/w/Keris_partisan_of_amascut
-    private static final int DRAGON_CROSSBOW_LMS_ID = 33460; // https://oldschool.runescape.wiki/w/Dragon_crossbow_(Last_Man_Standing)
-    private static final int SUNSPEAR_ID = 33722; // https://oldschool.runescape.wiki/w/Sunspear
+    private static final int HALLOWFELL_ID = 34027; // https://oldschool.runescape.wiki/w/Hallowfell
 
     // Add other weapons here if in the Runelite dev shell this prints a different value to it's actual speed:
     //
@@ -160,9 +158,7 @@ public class AttackTimerMetronomePlugin extends Plugin
     //  log.info("Speed {}", itemManager.getItemStats(<id_to_test>).getEquipment().getAspeed());
     private static final Map<Integer, Integer> NON_STANDARD_ATTACK_SPEEDS =
             new ImmutableMap.Builder<Integer, Integer>()
-                    .put(BLACK_GEM_KERIS_ID, 4)
-                    .put(DRAGON_CROSSBOW_LMS_ID, 6)
-                    .put(SUNSPEAR_ID, 5)
+                    .put(HALLOWFELL_ID, 6)
                     .build();
 
     // These animations are the ones which exceed the duration of their attack cooldown


### PR DESCRIPTION
## Summary

Add the Hallofell ID to the workaround map.

It safe to remove the old IDs:

```java
 var itemManager = inject(ItemManager.class);
 log.info("BLACK_GEM_KERIS_ID {}", itemManager.getItemStats(30891).getEquipment().getAspeed());
 log.info("DRAGON_CROSSBOW_LMS_ID {}", itemManager.getItemStats(33460).getEquipment().getAspeed());
 log.info("SUNSPEAR_ID {}", itemManager.getItemStats(33722).getEquipment().getAspeed());
 log.info("HALLOWFELL_IDed {}", itemManager.getItemStats(34027).getEquipment().getAspeed());
```
prints
```
[INFO] BLACK_GEM_KERIS_ID 4
[INFO] DRAGON_CROSSBOW_LMS_ID 6
[INFO] SUNSPEAR_ID 5
[ERROR] 
java.lang.NullPointerException
	at Shell.global(:5)
```
(Before the blackgem, dcb, and sunspear were all broken)

I also noticed some new "tanking" animations which throw off the plugin.

## Testing


https://github.com/user-attachments/assets/93657af8-7f19-4d4d-bf77-e995b03f375d

