### PR TITLE
Improve Red Keris

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Ticks until next attack may be enabled over your player's head.
 
 ## Updates
 
-## 1.2.8 - 1.2.9
+## 1.2.8 - 1.2.10
 
 * Fixes for Wyrmscraig (Hallowfell)
 * Fix regression in 1.1, greater corruption triggering cooldown
+* Red Keris Special Attack will now only be 8 ticks when landing the hit
 
 ## 1.2.3 - 1.2.7
 

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,7 +1,7 @@
 displayName=AttackTimer
 author=ngraves95,Lexer747
 build=standard
-version=1.2.9
+version=1.2.10
 description=A plugin to countdown until your next attack
 tags=pvm,timer,attack,combat,weapon
 plugins=com.attacktimer.AttackTimerMetronomePlugin

--- a/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
+++ b/src/main/java/com/attacktimer/AttackTimerMetronomePlugin.java
@@ -263,31 +263,45 @@ public class AttackTimerMetronomePlugin extends Plugin
 
     private int computeDamage(AttackStyle attackStyle, AttackProcedure atkType, AnimationData curAnimation)
     {
+        // https://oldschool.runescape.wiki/w/Combat#Experience_gain
         switch (atkType)
         {
-            case POWERED_STAVE:
+        case POWERED_STAVE:
+            // TODO not needed for any variable speed
+            return -1;
+        case MANUAL_AUTO_CAST:
+            if (attackStyle == AttackStyle.DEFENSIVE_CASTING || attackStyle == AttackStyle.DEFENSIVE)
+            {
+                // just use the defense exp to compute the damage
+                return Utils.getLastDelta(combatExpEarned.get(Skill.DEFENCE));
+            }
+            else
+            {
+                // deduct the fixed exp based on the spell
+                // (for now this only works for dark demon bane which awkwardly gives fractional exp)
+                final var mageExp = Utils.getLastDelta(combatExpEarned.get(Skill.MAGIC));
+                if (curAnimation != AnimationData.MAGIC_ARCEUUS_DEMONBANE)
+                {
+                    return -1;
+                }
+                return (int) Math.ceil(((double) mageExp - 43.5D) / 2.0D);
+            }
+        case MELEE_OR_RANGE:
+            switch (attackStyle)
+            {
+            case ACCURATE:
+                final var attackExp = Utils.getLastDelta(combatExpEarned.get(Skill.ATTACK));
+                return (int) ((double) attackExp / 4.0D);
+            case AGGRESSIVE:
+                final var strExp = Utils.getLastDelta(combatExpEarned.get(Skill.STRENGTH));
+                return (int) ((double) strExp / 4.0D);
+            case DEFENSIVE:
+                final var defExp = Utils.getLastDelta(combatExpEarned.get(Skill.DEFENCE));
+                return (int) ((double) defExp / 4.0D);
+            default:
                 // TODO not needed for any variable speed
                 return -1;
-            case MANUAL_AUTO_CAST:
-                if (attackStyle == AttackStyle.DEFENSIVE_CASTING || attackStyle == AttackStyle.DEFENSIVE)
-                {
-                    // just use the defense exp to compute the damage
-                    return Utils.getLastDelta(combatExpEarned.get(Skill.DEFENCE));
-                }
-                else
-                {
-                    // deduct the fixed exp based on the spell
-                    // (for now this only works for dark demon bane which awkwardly gives fractional exp)
-                    var mageExp = Utils.getLastDelta(combatExpEarned.get(Skill.MAGIC));
-                    if (curAnimation != AnimationData.MAGIC_ARCEUUS_DEMONBANE)
-                    {
-                        return -1;
-                    }
-                    return (int) Math.ceil(((double) mageExp - 43.5D) / 2.0D);
-                }
-            case MELEE_OR_RANGE:
-                // TODO not needed for any variable speed
-                return -1;
+            }
         }
         return -1;
     }
@@ -487,7 +501,9 @@ public class AttackTimerMetronomePlugin extends Plugin
     private static final String FAST_GNOME_FOOD = "worm hole|tangled toads legs|veg ball|chocolate bomb|worm crunchies|toad crunchies|"
             + "choc chip crunchies|spicy crunchies|fruit batta|cheese and tomato batta|toad batta|vegetable batta|worm batta";
     private static final String FAST_FOOD = "karambwan|halibut";
-    // TODO ^ find out the food messages for https://oldschool.runescape.wiki/w/Crystal_paddlefish and https://oldschool.runescape.wiki/w/Corrupted_paddlefish
+    // Unfortunately these have just the generic "You eat the food." so there is no easy way to tell if you
+    // have the quicker eat delay. https://oldschool.runescape.wiki/w/Crystal_paddlefish and
+    // https://oldschool.runescape.wiki/w/Corrupted_paddlefish
     private static final Pattern FAST_EAT = Pattern.compile("(" + FAST_FOOD + "|" + FAST_GNOME_FOOD + ")", Pattern.CASE_INSENSITIVE);
 
     @Subscribe

--- a/src/main/java/com/attacktimer/VariableSpeed/RedKerisSpec.java
+++ b/src/main/java/com/attacktimer/VariableSpeed/RedKerisSpec.java
@@ -34,9 +34,14 @@ public class RedKerisSpec implements IVariableSpeed
     public int apply(final Client client, final AnimationData curAnimation, final AttackProcedure atkType,
             final int damageDealt, final int lastSpecDelta, final int baseSpeed, final int curSpeed)
     {
-        if (curAnimation == AnimationData.MELEE_RED_KERIS_SPEC)
+        // https://oldschool.runescape.wiki/w/Keris_partisan_of_corruption#Special_attack
+        if (lastSpecDelta != -750 || curAnimation != AnimationData.MELEE_RED_KERIS_SPEC)
         {
-            // TODO add miss/hit tracking code, if we missed this delay is not applied
+            return curSpeed;
+        }
+        // We are using the special attack, but we only slow down if we hit a number
+        if (damageDealt > 0)
+        {
             return curSpeed + 4;
         }
         return curSpeed;


### PR DESCRIPTION
## Summary

In #140 I added the ability for the plugin to track damage and spec costs. With this we can improve the Red Keris Spec variable speed to actually inspect these values and only increment the speed when a hit lands.

## Testing

https://github.com/user-attachments/assets/407e3f47-8063-4acb-a898-24565e2d60bd

